### PR TITLE
v1.0.4

### DIFF
--- a/accumulate/utils.go
+++ b/accumulate/utils.go
@@ -11,12 +11,12 @@ func GenerateTokenAccount(adi string, chainId int64, symbol string) string {
 	return filepath.Join(adi, strconv.Itoa(int(chainId))+"-"+symbol)
 }
 
-// Generate bridge data account in format {chainId}:{action}
+// Generate bridge data account in format audit:{chainId}:{action}
 func GenerateReleaseDataAccount(adi string, chainId int64, action string) string {
 	return filepath.Join(adi, "audit:"+strconv.Itoa(int(chainId))+":"+action)
 }
 
-// Generate bridge data account in format {chainId}:{action}:{symbol}
+// Generate bridge data account in format audit:{chainId}:{action}:{symbol}
 func GenerateMintDataAccount(adi string, chainId int64, action string, symbol string) string {
 	return filepath.Join(adi, "audit:"+strconv.Itoa(int(chainId))+":"+action+":"+symbol)
 }

--- a/accumulate/utils.go
+++ b/accumulate/utils.go
@@ -13,12 +13,12 @@ func GenerateTokenAccount(adi string, chainId int64, symbol string) string {
 
 // Generate bridge data account in format {chainId}:{action}
 func GenerateReleaseDataAccount(adi string, chainId int64, action string) string {
-	return filepath.Join(adi, strconv.Itoa(int(chainId))+":"+action)
+	return filepath.Join(adi, "audit:"+strconv.Itoa(int(chainId))+":"+action)
 }
 
 // Generate bridge data account in format {chainId}:{action}:{symbol}
 func GenerateMintDataAccount(adi string, chainId int64, action string, symbol string) string {
-	return filepath.Join(adi, strconv.Itoa(int(chainId))+":"+action+":"+symbol)
+	return filepath.Join(adi, "audit:"+strconv.Itoa(int(chainId))+":"+action+":"+symbol)
 }
 
 // Generate pending chain in format {account}#pending

--- a/main.go
+++ b/main.go
@@ -451,7 +451,7 @@ func processBurnEvents(a *accumulate.AccumulateClient, e *evm.EVMClient, bridge 
 		select {
 		default:
 
-			time.Sleep(time.Duration(30) * time.Second)
+			time.Sleep(time.Duration(60) * time.Second)
 
 			releaseQueue := accumulate.GenerateReleaseDataAccount(a.ADI, int64(e.ChainId), accumulate.ACC_RELEASE_QUEUE)
 
@@ -743,7 +743,7 @@ func processNewDeposits(a *accumulate.AccumulateClient, e *evm.EVMClient, g *gno
 		select {
 		default:
 
-			time.Sleep(time.Duration(30) * time.Second)
+			time.Sleep(time.Duration(60) * time.Second)
 
 			if global.IsOnline {
 
@@ -1192,7 +1192,7 @@ func submitEVMTxs(e *evm.EVMClient, g *gnosis.Gnosis, die chan bool) {
 		select {
 		default:
 
-			time.Sleep(time.Duration(30) * time.Second)
+			time.Sleep(time.Duration(60) * time.Second)
 
 			if global.IsOnline {
 


### PR DESCRIPTION
- migration to new data accounts format `audit:{chainId}:{action}...`
- CLI update to support multi-chain token registry
- increased time intervals between bridge iterations from 30 to 60 s